### PR TITLE
Play nice with HTTPS installations

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1,6 +1,6 @@
 @import url(../../../stylesheets/application.css);
 @import url(font-awesome.css);
-@import url(http://fonts.googleapis.com/css?family=Lato:300,400,700);
+@import url(//fonts.googleapis.com/css?family=Lato:300,400,700);
 @import url(theme.css);
 @import url(color_tasks.css);
 @import url(DMSF.css);


### PR DESCRIPTION
When running Redmine on HTTPS the following error will pop up in the Firebug console:

> Blocked loading mixed active content "http://fonts.googleapis.com/css?family=Lato:300,400,700"

This can be fixed by replacing `http://` with `//`, the protocol relative URL. See fe. http://www.paulirish.com/2010/the-protocol-relative-url/
