### PR TITLE
Readable dropdowns for odd default colours

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -297,8 +297,6 @@ p.nodata{
 div.issue { background: #f6f6f6; }
 /*============ SELECT ==========*/
 select {
-    background: #fff;
-    border-color: #cccccc;
     outline:none;
     display: inline-block;
     cursor:pointer;


### PR DESCRIPTION
Currently when you use a non-standard colour scheme (such as white text on black) the dropdowns turn unreadable. This happens because only the background color is set, resulting in white text (my theme's foreground colour) on a white background (flatly's background colour)

Before:
![before](http://ghost.qtea.nl/tmp/flatly_light_redmine_select_before.png)

After:
![after](http://ghost.qtea.nl/tmp/flatly_light_redmine_select_after.png)
