### PR TITLE
Load Google css over HTTPS to prevent loading error in HTTPS-only instances.

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1,6 +1,6 @@
 @import url(../../../stylesheets/application.css);
 @import url(font-awesome.css);
-@import url(http://fonts.googleapis.com/css?family=Lato:300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Lato:300,400,700);
 @import url(theme.css);
 @import url(color_tasks.css);
 @import url(DMSF.css);


### PR DESCRIPTION
The change is required to prevent the following error (From Chrome's console):

> Mixed Content: The page at 'https://redmineinstance' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Lato:300,400,700'. This request has been blocked; the content must be served over HTTPS.
