### PR TITLE
Hide empty white square when printing

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -95,6 +95,12 @@ h1:first-letter{
   background-color: rgba(255, 255, 255, 0.9);
 }
 
+@media print {
+  #menu {
+    display: none;
+  }
+}
+
 #top-menu.open{
   left: 0;
 }


### PR DESCRIPTION
When printing any page you'll get an empty white square on the top left of the page. Chrome's print preview also shows this square.

This can be fixed by setting `#menu` to `display: none` when printing.
