### PR TITLE
Upadate stylesheets/project.css

### DIFF
--- a/stylesheets/projects.css
+++ b/stylesheets/projects.css
@@ -4,9 +4,11 @@ ul.projects li.root {
   border: 1px solid #d7d7d7;
 }
 
-.theme-Flatly.light.redmine #projects-index {
-  column-count: unset;
-  column-width: unset;
-  -webkit-column-count: unset;
-  -webkit-column-width: unset;
+#projects-index {
+  column-count: auto;
+  column-width: auto;
+  -webkit-column-count: auto;
+  -webkit-column-width: auto;
+  -moz-column-count: auto;
+  -moz-column-width: auto;
 }


### PR DESCRIPTION
Existing style for the Project Index Page does not work. The <Li> elements are broken between the columns and it looks ugly. Ones need to correct the rule for #projects-index.