### PR TITLE
Fit Project names in drop-down

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -202,6 +202,7 @@ label[for="q"]{
 }
 #project-jump .drdn-content {
   border-radius: 0;
+  width: fit-content;
 }
 #project-jump .drdn-content .quick-search {
   margin: 0;


### PR DESCRIPTION
Projects drop-down has a fixed width of 280 pixels. This results in more descriptive project names cutting off in the favorites drop-down.

![image](https://user-images.githubusercontent.com/53229879/68434595-9bcea000-0176-11ea-8668-c7f8283b495d.png)

Patch changes width to "fit-content" allowing the full Project name to display.

![image](https://user-images.githubusercontent.com/53229879/68434665-c15ba980-0176-11ea-88bf-c689910dcb0c.png)